### PR TITLE
Use new nix-darwin fork.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,16 +23,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1617358317,
-        "narHash": "sha256-ZZZrANL5c+1rdneo3F7YTU6Z8Btgga2mH7Hxrp0lHo4=",
+        "lastModified": 1617628871,
+        "narHash": "sha256-iliVGNHOPi26jcp6gfD8HAIFZr98y7Des6WBIUhrHRo=",
         "owner": "hackworthltd",
         "repo": "nix-darwin",
-        "rev": "9807bb45b1b97a770cfcb3dc0ad9a392c981af6a",
+        "rev": "b07785eec74e374929b35a19fde33f8a5c464641",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
-        "ref": "fixes-v2",
+        "ref": "fixes-v3",
         "repo": "nix-darwin",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
 
-    nix-darwin.url = github:hackworthltd/nix-darwin/fixes-v2;
+    nix-darwin.url = github:hackworthltd/nix-darwin/fixes-v3;
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
 
     flake-compat = {

--- a/test-configs/nix-darwin/minimal.nix
+++ b/test-configs/nix-darwin/minimal.nix
@@ -1,10 +1,8 @@
-# Note: we should be able to pass `system` here, but darwinSystem
-# doesn't support that yet.
-
 { lib
 , ...
 }:
 {
+  system = "x86_64-darwin";
   modules = lib.singleton
     ({ pkgs, ... }: {
       services.activate-system.enable = true;


### PR DESCRIPTION
This allows us to specify the darwinSystem system type at build time,
rather than eval time.